### PR TITLE
Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 # Tasks
 
 - TODO Add command line interface instructions here
+- TODO Add option to stage, commit, and push README once badge updated?
 
 # Installing `python_coverage_badge` 📦
 To install this package, follow these two steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 # Tasks
 
-- TODO Add command line interface
+- TODO Add command line interface instructions here
 
 # Installing `python_coverage_badge` 📦
 To install this package, follow these two steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 # Tasks
 
-- TODO Add command line interface instructions here
 - TODO Add option to stage, commit, and push README once badge updated?
 
 # Installing `python_coverage_badge` 📦
@@ -30,18 +29,19 @@ To update the coverage badge of your repo, run the following from within the **r
 python -m python_coverage_badge
 ```
 
-
-# Install `python_coverage_badge` 📦
-Clone the repository with (or similar):
-```bash
-git clone https://github.com/JosephCrispell/timesheet.git
+There are a couple of command line arguments you can use, take a look with `python -m python_coverage_badge`:
 ```
+usage: python_coverage_badge [-h] [-d [directory]] [-r [readme_path]]
 
-And install by running this in repository:
-```bash
-pip install -e .
+Welcome to python_coverage_badge! A tool to create and maintain a python package unit test coverage badge in README.md
+
+options:
+  -h, --help  show this help message and exit
+  -d [directory], --directory [directory]
+              Provide path to directory to run python_coverage_badge in. (default: .)
+  -r [readme_path], --readme [readme_path]
+              Provide path to README.md relative to directory provided. (default: README.md)
 ```
-> Note the `-e` in above means the package will automatically update as you change the codebase.
 
 # For Developers
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-67.2%25-orange)
+![Code Coverage](https://img.shields.io/badge/coverage-79.6%25-green)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-79.6%25-green)
+![Code Coverage](https://img.shields.io/badge/coverage-79.2%25-green)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-75.4%25-green)
+![Code Coverage](https://img.shields.io/badge/coverage-67.2%25-orange)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/python_coverage_badge/__main__.py
+++ b/python_coverage_badge/__main__.py
@@ -5,7 +5,6 @@ from python_coverage_badge import (
 
 # TODO add more colour categories to scale
 # TODO add unittest for main
-# TODO add unittests for cli
 
 
 def main():

--- a/python_coverage_badge/__main__.py
+++ b/python_coverage_badge/__main__.py
@@ -4,7 +4,6 @@ from python_coverage_badge import (
 )  # functions for running coverage
 
 # TODO add more colour categories to scale
-# TODO add command line interface
 # TODO add unittest for main
 # TODO add unittests for cli
 

--- a/python_coverage_badge/__main__.py
+++ b/python_coverage_badge/__main__.py
@@ -1,31 +1,21 @@
-# Load packages
-from pathlib import Path  # handling file paths
-
 # Local imports
 from python_coverage_badge import (
-    unittest_coverage_functions,
+    command_line_interface_functions,
 )  # functions for running coverage
 
 # TODO add more colour categories to scale
 # TODO add command line interface
+# TODO add unittest for main
+# TODO add unittests for cli
 
 
 def main():
 
-    # Run code coverage
-    coverage_dataframe = unittest_coverage_functions.run_code_coverage()
+    # Build interface
+    parser = command_line_interface_functions.build_command_line_interface()
 
-    # Build badge
-    coverage_badge_url = unittest_coverage_functions.make_coverage_badge_url(
-        coverage_dataframe
-    )
-
-    # Update badge in README
-    unittest_coverage_functions.replace_regex_in_file(
-        file_path=Path("README.md"),
-        pattern_regex=r"\!\[Code Coverage\]\(.+\)",
-        replacement=f"![Code Coverage]({coverage_badge_url})",
-    )
+    # Parse arguments
+    command_line_interface_functions.parse_command_line_arguments(parser)
 
 
 if __name__ == "__main__":

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -55,7 +55,9 @@ def build_command_line_interface() -> argparse.ArgumentParser:
 
 
 def parse_command_line_arguments(
-    parser: argparse.ArgumentParser, arguments: list[str] = sys.argv[1:]
+    parser: argparse.ArgumentParser,
+    arguments: list[str] = sys.argv[1:],
+    testing: bool = False,
 ):
     """Parse command line arguments based on parser provided
 
@@ -71,17 +73,25 @@ def parse_command_line_arguments(
     # Get arguments
     args = parser.parse_args(arguments)
 
-    # Run coverage package (which runs unittests and generates report
-    coverage_dataframe = unittest_coverage_functions.run_code_coverage(args.directory)
+    # Check if running unittests
+    if not testing:
 
-    # Build the badge url
-    coverage_badge_url = unittest_coverage_functions.make_coverage_badge_url(
-        coverage_dataframe
-    )
+        # Run coverage package (which runs unittests and generates report
+        coverage_dataframe = unittest_coverage_functions.run_code_coverage(
+            args.directory
+        )
 
-    # Update badge in README
-    unittest_coverage_functions.replace_regex_in_file(
-        file_path=Path(args.readme),
-        pattern_regex=r"\!\[Code Coverage\]\(.+\)",
-        replacement=f"![Code Coverage]({coverage_badge_url})",
-    )
+        # Build the badge url
+        coverage_badge_url = unittest_coverage_functions.make_coverage_badge_url(
+            coverage_dataframe
+        )
+
+        # Update badge in README
+        unittest_coverage_functions.replace_regex_in_file(
+            file_path=Path(args.directory, args.readme),
+            pattern_regex=r"\!\[Code Coverage\]\(.+\)",
+            replacement=f"![Code Coverage]({coverage_badge_url})",
+        )
+
+    else:
+        return args

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -3,6 +3,7 @@ import argparse  # parsing command line arguments
 from pathlib import Path  # handling file paths
 from datetime import datetime  # working with dates and times
 import sys  # accessing command line arguments
+import os  # Change directory
 
 # Local imports
 from python_coverage_badge import unittest_coverage_functions
@@ -67,6 +68,7 @@ def parse_command_line_arguments(
             required normally but this means we can unittest
             (see: https://stackoverflow.com/questions/18160078/how-do-you-write-tests-for-the-argparse-portion-of-a-python-module).
             Defaults to sys.argv[:1] (arguments minus script name).
+        testing (bool): check if running unit tests as don't want to run coverage package if we are. Defaults to False.
 
     """
 
@@ -76,10 +78,11 @@ def parse_command_line_arguments(
     # Check if running unittests
     if not testing:
 
+        # Set target directory
+        os.chdir(args.directory)
+
         # Run coverage package (which runs unittests and generates report
-        coverage_dataframe = unittest_coverage_functions.run_code_coverage(
-            args.directory
-        )
+        coverage_dataframe = unittest_coverage_functions.run_code_coverage()
 
         # Build the badge url
         coverage_badge_url = unittest_coverage_functions.make_coverage_badge_url(

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -1,0 +1,66 @@
+# Load packages
+import argparse  # parsing command line arguments
+from pathlib import Path  # handling file paths
+from datetime import datetime  # working with dates and times
+import sys  # accessing command line arguments
+
+# Local imports
+import python_coverage_badge
+
+
+def build_command_line_interface() -> argparse.ArgumentParser:
+    """Builds command line interface for python_coverage_badge package
+
+    Adds the following arguments:
+    - Target directory: -d/--directory
+    - Target README: -r/--readme
+    - Run coverage: -c/--coverage
+    - Update badge: -b/--badge
+
+    Returns:
+        argparse.ArgumentParser: argument parser
+    """
+
+    # Write welcome message
+    welcome_message = "Welcome to python_coverage_badge! A tool to create and maintain a python package unit test coverage badge in README.md"
+
+    # Initialize parser
+    parser = argparse.ArgumentParser(
+        prog="python_coverage_badge",
+        description=welcome_message,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # Shows default values for parameters
+    )
+
+    # Add arguments
+    parser.add_argument(
+        "-d",
+        "--directory",
+        nargs="?",  # Accept 0 or 1 arguments
+        default=".",  # Default value
+        metavar="directory",
+        type=str,
+        help="Provide path to directory to run python_coverage_badge in.",
+    )
+    parser.add_argument(
+        "-r",
+        "--readme",
+        nargs="?",  # Accept 0 or 1 arguments
+        default="README.md",  # Default value
+        metavar="directory",
+        type=str,
+        help="Provide path to README.md relative to directory provided.",
+    )
+    parser.add_argument(
+        "-c",
+        "--coverage",
+        action="store_true",
+        help="Run the python coverage package the executes unit tests and generates coverage summary.",
+    )
+    parser.add_argument(
+        "-b",
+        "--badge",
+        action="store_true",
+        help="Update the coverage badge in README.md.",
+    )
+
+    return parser

--- a/python_coverage_badge/unittest_coverage_functions.py
+++ b/python_coverage_badge/unittest_coverage_functions.py
@@ -31,7 +31,7 @@ def parse_coverage_report(coverage_report_string: str) -> pd.DataFrame:
     return coverage_dataframe
 
 
-def run_code_coverage(directory: Path = Path(".")) -> pd.DataFrame:
+def run_code_coverage() -> pd.DataFrame:
     """Runs coverage tool in command line and returns report
 
     Will send warning if running coverage package is failing and return empty dataframe
@@ -40,6 +40,8 @@ def run_code_coverage(directory: Path = Path(".")) -> pd.DataFrame:
         pd.DataFrame : coverage report as dataframe if coverage passing; empty dataframe if coverage failing
     """
 
+    # Change to the directory provided
+
     # Run code coverage calculation
     # Check out useful subprocess function docs: https://www.datacamp.com/tutorial/python-subprocess
     coverage_command = [
@@ -47,7 +49,7 @@ def run_code_coverage(directory: Path = Path(".")) -> pd.DataFrame:
         "-m",
         "coverage",
         "run",
-        "--source=" + str(directory),
+        "--source=.",
         "-m",
         "unittest",
     ]

--- a/python_coverage_badge/unittest_coverage_functions.py
+++ b/python_coverage_badge/unittest_coverage_functions.py
@@ -31,7 +31,7 @@ def parse_coverage_report(coverage_report_string: str) -> pd.DataFrame:
     return coverage_dataframe
 
 
-def run_code_coverage() -> pd.DataFrame:
+def run_code_coverage(directory: Path = Path(".")) -> pd.DataFrame:
     """Runs coverage tool in command line and returns report
 
     Will send warning if running coverage package is failing and return empty dataframe
@@ -47,7 +47,7 @@ def run_code_coverage() -> pd.DataFrame:
         "-m",
         "coverage",
         "run",
-        "--source=.",
+        "--source=" + str(directory),
         "-m",
         "unittest",
     ]

--- a/tests/test_command_line_interface_functions.py
+++ b/tests/test_command_line_interface_functions.py
@@ -1,0 +1,55 @@
+# Load packages
+import unittest  # running tests
+from pathlib import Path  # handling file paths
+
+# Local imports
+from python_coverage_badge import command_line_interface_functions  # cli functions
+
+
+class TestCommandLineInterfaceFunctions(unittest.TestCase):
+    def test_build_command_line_interface(self):
+        """Test command line parser is built"""
+
+        # Build the command line interface parser
+        parser = command_line_interface_functions.build_command_line_interface()
+
+        # Check argument parser returned
+        self.assertEqual(
+            str(type(parser)),
+            "<class 'argparse.ArgumentParser'>",
+            "Check argument parser returned",
+        )
+
+    def test_parse_command_line_arguments(self):
+
+        # Build the command line interface parser
+        parser = command_line_interface_functions.build_command_line_interface()
+
+        # Define the command line arguments and parse
+        directory = "test_directory"
+        readme = "test_README"
+        arguments = [
+            "--directory",
+            directory,
+            "--readme",
+            readme,
+        ]
+        args = command_line_interface_functions.parse_command_line_arguments(
+            parser, arguments, testing=True
+        )
+
+        # Check args exist
+        self.assertEqual(
+            directory,
+            args.directory,
+            "Check directory stored as argument",
+        )
+        self.assertEqual(
+            readme,
+            args.readme,
+            "Check readme stored as argument",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added a command line interface for the package. This mainly involved creating the `python_coverage_badge/command_line_interface_functions.py` and updating `python_coverage_badge/__main__.py`. A lot of content was copied across from `timesheet`.

Simple command line interface:
```
usage: python_coverage_badge [-h] [-d [directory]] [-r [readme_path]]

Welcome to python_coverage_badge! A tool to create and maintain a python package unit test coverage badge in README.md

options:
  -h, --help            show this help message and exit
  -d [directory], --directory [directory]
                        Provide path to directory to run python_coverage_badge in. (default: .)
  -r [readme_path], --readme [readme_path]
                        Provide path to README.md relative to directory provided. (default: README.md)
```