### PR TITLE
Git readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-79.3%25-green)
+![Code Coverage](https://img.shields.io/badge/coverage-80.6%25-green)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-75.0%25-green)
+![Code Coverage](https://img.shields.io/badge/coverage-71.8%25-orange)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 # Tasks
 
-- TODO Add tests for git functions
 - TODO Add tests for main
+- TODO improve coverage of tests for git functions if possible
 
 # Installing `python_coverage_badge` 📦
 To install this package, follow these two steps:

--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ I created the following simple diagram using [mermaid](https://mermaid.js.org/) 
         test_git;
         test_main;
     end
-    unittests .-> main
+    unittests .-> coverage_functions
 ```

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ I created the following simple diagram using [mermaid](https://mermaid.js.org/) 
     cli_functions[python_coverage_badge/command_line_interface_functions.py] .-> main;
     cli_functions .-> test_cli[tests/test_command_line_interface_functions.py];
     git_functions[python_coverage_badge/git_functions.py] .-> main;
-    git_functions .-> test_cli[tests/test_git_functions.py];
+    git_functions .-> test_git[tests/test_git_functions.py];
     subgraph "unittests"
         test_coverage;
         test_cli;
-        test_git_functions;
+        test_git;
         test_main;
     end
     unittests .-> main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-80.6%25-green)
+![Code Coverage](https://img.shields.io/badge/coverage-80.7%25-green)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 - TODO Add tests for git functions
 - TODO Add tests for main
-- TODO Update doctree
 
 # Installing `python_coverage_badge` 📦
 To install this package, follow these two steps:
@@ -57,10 +56,15 @@ Directory tree generated using [file-tree-generator](https://marketplace.visuals
 📦python_coverage_badge
  ┣ 📂python_coverage_badge
  ┃ ┣ 📜__main__.py # script that is called when you call package (python -m python_coverage_badge)
+ ┃ ┣ 📜command_line_interface_functions.py # functions for the command line interface
+ ┃ ┣ 📜git_functions.py # functions to staging, committing, and pushing updated README to remote
  ┃ ┣ 📜unittest_coverage_functions.py # functions to calculate coverage and update badge
  ┃ ┗ 📜__init__.py
  ┣ 📂tests
- ┃ ┣ 📜test_unittest_coverage_functions.py # unit tests
+ ┃ ┣ 📜test_command_line_interface_functions.py # unit tests for cli
+ ┃ ┣ 📜test_git_functions.py # unit tests for git functions
+ ┃ ┣ 📜test_main.py # unit tests for main script
+ ┃ ┣ 📜test_unittest_coverage_functions.py # unit tests for functions to create/update coverage badge
  ┃ ┗ 📜__init__.py
  ┣ 📜.gitignore
  ┣ 📜.pre-commit-config.yaml # precommit workflow
@@ -96,11 +100,16 @@ I created the following simple diagram using [mermaid](https://mermaid.js.org/) 
     coverage_functions[python_coverage_badge/unittest_coverage_functions.py] .-> main[python_coverage_badge/__main__.py];
     coverage_functions .-> test_coverage[tests/test_unittest_coverage_functions.py];
     main --> readme[README.md];
+    main .-> test_main[tests/test_main.py];
     cli_functions[python_coverage_badge/command_line_interface_functions.py] .-> main;
     cli_functions .-> test_cli[tests/test_command_line_interface_functions.py];
+    git_functions[python_coverage_badge/git_functions.py] .-> main;
+    git_functions .-> test_cli[tests/test_git_functions.py];
     subgraph "unittests"
         test_coverage;
         test_cli;
+        test_git_functions;
+        test_main;
     end
     unittests .-> main
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-79.2%25-green)
+![Code Coverage](https://img.shields.io/badge/coverage-75.0%25-green)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 # Tasks
 
-- TODO Add option to stage, commit, and push README once badge updated?
+- TODO Add tests for git functions
+- TODO Add tests for main
 - TODO Update doctree
 
 # Installing `python_coverage_badge` 📦

--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ To update the coverage badge of your repo, run the following from within the **r
 python -m python_coverage_badge
 ```
 
-There are a couple of command line arguments you can use, take a look with `python -m python_coverage_badge`:
+There are a couple of command line arguments you can use, take a look with `python -m python_coverage_badge --help`:
 ```
-usage: python_coverage_badge [-h] [-d [directory]] [-r [readme_path]]
+usage: python_coverage_badge [-h] [-d [directory]] [-r [readme_path]] [-g]
 
 Welcome to python_coverage_badge! A tool to create and maintain a python package unit test coverage badge in README.md
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
   -d [directory], --directory [directory]
-              Provide path to directory to run python_coverage_badge in. (default: .)
+                        Provide path to directory to run python_coverage_badge in. (default: .)
   -r [readme_path], --readme [readme_path]
-              Provide path to README.md relative to directory provided. (default: README.md)
+                        Provide path to README.md relative to directory provided. (default: README.md)
+  -g, --git_push        Stage, commit, and push the updated README file (-r/--readme) using git. (default: False)
 ```
 
 # For Developers
@@ -59,13 +60,13 @@ Directory tree generated using [file-tree-generator](https://marketplace.visuals
  ┃ ┣ 📜command_line_interface_functions.py # functions for the command line interface
  ┃ ┣ 📜git_functions.py # functions to staging, committing, and pushing updated README to remote
  ┃ ┣ 📜unittest_coverage_functions.py # functions to calculate coverage and update badge
- ┃ ┗ 📜__init__.py
+ ┃ ┗ 📜__init__.py # package structure/info
  ┣ 📂tests
  ┃ ┣ 📜test_command_line_interface_functions.py # unit tests for cli
  ┃ ┣ 📜test_git_functions.py # unit tests for git functions
  ┃ ┣ 📜test_main.py # unit tests for main script
  ┃ ┣ 📜test_unittest_coverage_functions.py # unit tests for functions to create/update coverage badge
- ┃ ┗ 📜__init__.py
+ ┃ ┗ 📜__init__.py # package structure/info
  ┣ 📜.gitignore
  ┣ 📜.pre-commit-config.yaml # precommit workflow
  ┣ 📜LICENSE
@@ -81,7 +82,7 @@ Install python [`pre-commit`](https://pre-commit.com/) with:
 pip install pre-commit
 ```
 
-Within repository folder run:
+Within repository folder run to install hooks:
 ```bash
 pre-commit install
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-71.8%25-orange)
+![Code Coverage](https://img.shields.io/badge/coverage-79.3%25-green)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 # Tasks
 
 - TODO Add option to stage, commit, and push README once badge updated?
+- TODO Update doctree
 
 # Installing `python_coverage_badge` 📦
 To install this package, follow these two steps:
@@ -81,9 +82,7 @@ pre-commit install
 ```
 
 ## Running tests 🧪
-[Unit tests](https://realpython.com/python-testing/) (using the [`unittest`](https://docs.python.org/3/library/unittest.html) package) are in `tests/` can be ran with.
-
-To run all tests together:
+[Unit tests](https://realpython.com/python-testing/) (using the [`unittest`](https://docs.python.org/3/library/unittest.html) package) are in `tests/` can be ran all together with:
 ```bash
 python -m unittest
 ```
@@ -96,8 +95,11 @@ I created the following simple diagram using [mermaid](https://mermaid.js.org/) 
     coverage_functions[python_coverage_badge/unittest_coverage_functions.py] .-> main[python_coverage_badge/__main__.py];
     coverage_functions .-> test_coverage[tests/test_unittest_coverage_functions.py];
     main --> readme[README.md];
+    cli_functions[python_coverage_badge/command_line_interface_functions.py] .-> main;
+    cli_functions .-> test_cli[tests/test_command_line_interface_functions.py];
     subgraph "unittests"
-        test_coverage[tests/test_unittest_coverage_functions.py];
+        test_coverage;
+        test_cli;
     end
     unittests .-> main
 ```

--- a/python_coverage_badge/__main__.py
+++ b/python_coverage_badge/__main__.py
@@ -4,8 +4,6 @@ from python_coverage_badge import (
 )  # functions for running coverage
 
 # TODO add more colour categories to scale
-# TODO add unittest for main
-# TODO update to run git
 
 
 def main():

--- a/python_coverage_badge/__main__.py
+++ b/python_coverage_badge/__main__.py
@@ -5,6 +5,7 @@ from python_coverage_badge import (
 
 # TODO add more colour categories to scale
 # TODO add unittest for main
+# TODO update to run git
 
 
 def main():

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -7,6 +7,7 @@ import os  # Change directory
 
 # Local imports
 from python_coverage_badge import unittest_coverage_functions
+from python_coverage_badge import git_functions
 
 # TODO add git argument
 
@@ -17,8 +18,7 @@ def build_command_line_interface() -> argparse.ArgumentParser:
     Adds the following arguments:
     - Target directory: -d/--directory
     - Target README: -r/--readme
-    - Run coverage: -c/--coverage
-    - Update badge: -b/--badge
+    - Push changes: -g/--git_push
 
     Returns:
         argparse.ArgumentParser: argument parser
@@ -53,6 +53,12 @@ def build_command_line_interface() -> argparse.ArgumentParser:
         type=str,
         help="Provide path to README.md relative to directory provided.",
     )
+    parser.add_argument(
+        "-g",
+        "--git_push",
+        action="store_false",
+        help="Stage, commit, and push the updated README file (-r/--readme) using git.",
+    )
 
     return parser
 
@@ -71,7 +77,6 @@ def parse_command_line_arguments(
             (see: https://stackoverflow.com/questions/18160078/how-do-you-write-tests-for-the-argparse-portion-of-a-python-module).
             Defaults to sys.argv[:1] (arguments minus script name).
         testing (bool): check if running unit tests as don't want to run coverage package if we are. Defaults to False.
-
     """
 
     # Get arguments
@@ -97,6 +102,14 @@ def parse_command_line_arguments(
             pattern_regex=r"\!\[Code Coverage\]\(.+\)",
             replacement=f"![Code Coverage]({coverage_badge_url})",
         )
+
+        # Check if pushing changes
+        if args.git_push:
+
+            # Stage, commit, and push updated README
+            git_functions.push_updated_readme(
+                readme_path=Path(args.directory, args.readme)
+            )
 
     else:
         return args

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -8,6 +8,8 @@ import os  # Change directory
 # Local imports
 from python_coverage_badge import unittest_coverage_functions
 
+# TODO add git argument
+
 
 def build_command_line_interface() -> argparse.ArgumentParser:
     """Builds command line interface for python_coverage_badge package

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -56,7 +56,7 @@ def build_command_line_interface() -> argparse.ArgumentParser:
     parser.add_argument(
         "-g",
         "--git_push",
-        action="store_false",
+        action="store_true",
         help="Stage, commit, and push the updated README file (-r/--readme) using git.",
     )
 

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -56,7 +56,7 @@ def push_updated_readme(
         readme_path_str = str(readme_path)
 
         # Stage the changes (updated badge)
-        send_command("git", "status", readme_path_str)
+        send_command("git", "add", readme_path_str)
 
         # Check if committing and pushing
         if commit_and_push:

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -20,27 +20,6 @@ def push_updated_readme(readme_path: Path = Path("README.md")):
     push_changes()
 
 
-def run_command_without_collecting_output(command: list[str]):
-    """Runs command in the command line (terminal)
-
-    Args:
-        command (list[str]): command to run
-
-    Raises:
-        subprocess.CalledProcessError: throws error if command fails
-    """
-
-    # Run the command
-    command_result = subprocess.run(command, capture_output=True, text=True)
-
-    # Check command ran ok
-    if command_result != 0:
-
-        raise subprocess.CalledProcessError(
-            f"Command provided ({' '.join(command)}) failed with code: {command_result.returncode}. Error message:\n\n{command_result.stderr}"
-        )
-
-
 def stage_file(file_path: Path):
     """Use git to stage file
 
@@ -49,32 +28,28 @@ def stage_file(file_path: Path):
     """
 
     # Build the command to stage file
-    staging_command = ["git", "add", repr(file_path)]
+    staging_command = ["git", "add", str(file_path)]
 
     # Run the command
-    run_command_without_collecting_output(staging_command)
+    subprocess.run(staging_command, check=True)
 
 
 def commit_changes(message: str):
     """Use git to commit changes made
 
-    Raises:
-        subprocess.CalledProcessError: throws error if command to commit changes fails
+    Args:
+        message (str): git commit message
     """
 
     # Build the command to commit changes
     commit_command = ["git", "commit", "-m", message]
 
     # Run the command
-    run_command_without_collecting_output(commit_command)
+    subprocess.run(commit_command, check=True)
 
 
-def push_changes(message: str):
-    """Use git to push committed changes
-
-    Raises:
-        subprocess.CalledProcessError: throws error if command to push committed changes fails
-    """
+def push_changes():
+    """Use git to push committed changes"""
 
     # Build the command to push changes
     push_command = [
@@ -83,4 +58,4 @@ def push_changes(message: str):
     ]
 
     # Run the command
-    run_command_without_collecting_output(push_command)
+    subprocess.run(push_command, check=True)

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -16,8 +16,9 @@ def check_if_file_changed_using_git(file_path: Path) -> bool:
         bool: True if files have changed and False otherwise
     """
     # Run git status command
-    git_status_command = ["git", "status", str(file_path)]
-    command_result = subprocess.run(git_status_command, capture_output=True, text=True)
+    command_result = send_command(
+        "git", "status", str(file_path), capture_output=True, text=True
+    )
 
     # Check if ran ok
     if command_result.returncode == 0:  # Passing
@@ -50,55 +51,34 @@ def push_updated_readme(
     # Check if updated README changed
     if check_if_file_changed_using_git(readme_path):
 
+        # Convert file path to string
+        readme_path_str = str(readme_path)
+
         # Stage the changes (updated badge)
-        stage_file(readme_path)
+        send_command("git", "status", readme_path_str)
 
         # Check if committing and pushing
         if commit_and_push:
 
             # Commit changes
-            commit_changes(message=f"Updated coverage badge in {readme_path}")
+            commit_message = f"Updated coverage badge in {readme_path}"
+            send_command("git", "commit", "-m", commit_message)
 
             # Push changes
-            push_changes()
+            send_command("git", "push")
 
 
-def stage_file(file_path: Path):
-    """Use git to stage file
+def send_command(*args, **kwargs):
+    """Send a command in the terminal
 
-    Args:
-        file_path (Path): path to file to stage
-    """
-
-    # Build the command to stage file
-    staging_command = ["git", "add", str(file_path)]
-
-    # Run the command
-    subprocess.run(staging_command, check=True)
-
-
-def commit_changes(message: str):
-    """Use git to commit changes made
+    Uses subprocess.run(). Note by default sets check to True to
+    check if command runs without failing.
 
     Args:
-        message (str): git commit message
+        command ([str]): command to run in terminal
+        *args: additional commands to send to subprocess.run()
     """
 
-    # Build the command to commit changes
-    commit_command = ["git", "commit", "-m", message]
-
     # Run the command
-    subprocess.run(commit_command, check=True)
-
-
-def push_changes():
-    """Use git to push committed changes"""
-
-    # Build the command to push changes
-    push_command = [
-        "git",
-        "push",
-    ]
-
-    # Run the command
-    subprocess.run(push_command, check=True)
+    result = subprocess.run(args, check=True, **kwargs)
+    return result

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -37,11 +37,14 @@ def check_if_file_changed_using_git(file_path: Path) -> bool:
     return True
 
 
-def push_updated_readme(readme_path: Path = Path("README.md")):
+def push_updated_readme(
+    readme_path: Path = Path("README.md"), commit_and_push: bool = True
+):
     """Uses git to stage, commit, and push changes to README.md (updated badge)
 
     Args:
         readme_path (Path, optional): path to README.md file. Defaults to Path("README.md").
+        commit_and_push (bool, optional): whether to push changes or not. Defaults to True.
     """
 
     # Check if updated README changed
@@ -50,11 +53,14 @@ def push_updated_readme(readme_path: Path = Path("README.md")):
         # Stage the changes (updated badge)
         stage_file(readme_path)
 
-        # Commit changes
-        commit_changes(message=f"Updated coverage badge in {readme_path}")
+        # Check if committing and pushing
+        if commit_and_push:
 
-        # Push changes
-        push_changes()
+            # Commit changes
+            commit_changes(message=f"Updated coverage badge in {readme_path}")
+
+            # Push changes
+            push_changes()
 
 
 def stage_file(file_path: Path):

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -3,6 +3,40 @@ import subprocess  # command line commands
 from pathlib import Path  # handling file paths
 
 
+def check_if_file_changed_using_git(file_path: Path) -> bool:
+    """Use git to check if file provided has changed in repo
+
+    Args:
+        file_path (Path): path to file that want to check
+
+    Raises:
+        subprocess.CalledProcessError: throws error if git status command fails
+
+    Returns:
+        bool: True if files have changed and False otherwise
+    """
+    # Run git status command
+    git_status_command = ["git", "status", str(file_path)]
+    command_result = subprocess.run(git_status_command, capture_output=True, text=True)
+
+    # Check if ran ok
+    if command_result.returncode == 0:  # Passing
+
+        # Check if there is anything to commit
+        if "nothing to commit" in command_result.stdout:
+            return False
+    else:
+        raise subprocess.CalledProcessError(
+            returncode=command_result.returncode,
+            cmd=command_result.args,
+            output=command_result.stdout,
+            stderr=command_result.stderr,
+        )
+
+    # If got to here there must be changes to commit
+    return True
+
+
 def push_updated_readme(readme_path: Path = Path("README.md")):
     """Uses git to stage, commit, and push changes to README.md (updated badge)
 
@@ -10,14 +44,17 @@ def push_updated_readme(readme_path: Path = Path("README.md")):
         readme_path (Path, optional): path to README.md file. Defaults to Path("README.md").
     """
 
-    # Stage the changes (updated badge)
-    stage_file(readme_path)
+    # Check if updated README changed
+    if check_if_file_changed_using_git(readme_path):
 
-    # Commit changes
-    commit_changes(message=f"Updated coverage badge in {readme_path}")
+        # Stage the changes (updated badge)
+        stage_file(readme_path)
 
-    # Push changes
-    push_changes()
+        # Commit changes
+        commit_changes(message=f"Updated coverage badge in {readme_path}")
+
+        # Push changes
+        push_changes()
 
 
 def stage_file(file_path: Path):

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -1,0 +1,86 @@
+# Load required libraries
+import subprocess  # command line commands
+from pathlib import Path  # handling file paths
+
+
+def push_updated_readme(readme_path: Path = Path("README.md")):
+    """Uses git to stage, commit, and push changes to README.md (updated badge)
+
+    Args:
+        readme_path (Path, optional): path to README.md file. Defaults to Path("README.md").
+    """
+
+    # Stage the changes (updated badge)
+    stage_file(readme_path)
+
+    # Commit changes
+    commit_changes(message=f"Updated coverage badge in {readme_path}")
+
+    # Push changes
+    push_changes()
+
+
+def run_command_without_collecting_output(command: list[str]):
+    """Runs command in the command line (terminal)
+
+    Args:
+        command (list[str]): command to run
+
+    Raises:
+        subprocess.CalledProcessError: throws error if command fails
+    """
+
+    # Run the command
+    command_result = subprocess.run(command, capture_output=True, text=True)
+
+    # Check command ran ok
+    if command_result != 0:
+
+        raise subprocess.CalledProcessError(
+            f"Command provided ({' '.join(command)}) failed with code: {command_result.returncode}. Error message:\n\n{command_result.stderr}"
+        )
+
+
+def stage_file(file_path: Path):
+    """Use git to stage file
+
+    Args:
+        file_path (Path): path to file to stage
+    """
+
+    # Build the command to stage file
+    staging_command = ["git", "add", repr(file_path)]
+
+    # Run the command
+    run_command_without_collecting_output(staging_command)
+
+
+def commit_changes(message: str):
+    """Use git to commit changes made
+
+    Raises:
+        subprocess.CalledProcessError: throws error if command to commit changes fails
+    """
+
+    # Build the command to commit changes
+    commit_command = ["git", "commit", "-m", message]
+
+    # Run the command
+    run_command_without_collecting_output(commit_command)
+
+
+def push_changes(message: str):
+    """Use git to push committed changes
+
+    Raises:
+        subprocess.CalledProcessError: throws error if command to push committed changes fails
+    """
+
+    # Build the command to push changes
+    push_command = [
+        "git",
+        "push",
+    ]
+
+    # Run the command
+    run_command_without_collecting_output(push_command)

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -38,6 +38,7 @@ def check_if_file_changed_using_git(file_path: Path) -> bool:
     return True
 
 
+# TODO run python -m python_coverage_badge --git_push to test
 def push_updated_readme(
     readme_path: Path = Path("README.md"), commit_and_push: bool = True
 ):

--- a/tests/test_git_functions.py
+++ b/tests/test_git_functions.py
@@ -14,8 +14,20 @@ from python_coverage_badge import (
 class TestGitFunctions(unittest.TestCase):
     def test_check_if_file_changed_using_git(self):
 
-        # TODO Add test in here!
-        print("hello! Tests to add!")
+        # Create a temporary file
+        temporary_file_path = Path("test_git_file_changed.txt")
+        file_lines = ["I", "am", "a", "really", "simple", "file", "\n"]
+        with open(temporary_file_path, "w") as file:
+            file.write("\n".join(file_lines))
+
+        # Check whether file changed by git
+        self.assertTrue(
+            git_functions.check_if_file_changed_using_git(temporary_file_path),
+            "Check file changed recognised by git",
+        )
+
+        # Remove temporary file
+        Path.unlink(temporary_file_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_git_functions.py
+++ b/tests/test_git_functions.py
@@ -6,7 +6,7 @@ import subprocess  # command line commands
 # Local imports
 from python_coverage_badge import (
     git_functions,
-)  # functions foir interacting with git
+)  # functions for interacting with git
 
 
 # TODO add tests

--- a/tests/test_git_functions.py
+++ b/tests/test_git_functions.py
@@ -1,6 +1,7 @@
 # Load packages
 import unittest  # running tests
 from pathlib import Path  # handling file paths
+import subprocess  # command line commands
 
 # Local imports
 from python_coverage_badge import (
@@ -25,6 +26,37 @@ class TestGitFunctions(unittest.TestCase):
             git_functions.check_if_file_changed_using_git(temporary_file_path),
             "Check file changed recognised by git",
         )
+
+        # Remove temporary file
+        Path.unlink(temporary_file_path)
+
+    def test_push_updated_readme(self):
+
+        # Create a temporary file
+        temporary_file_path = Path("test_git_file_changed.txt")
+        file_lines = ["I", "am", "a", "really", "simple", "file", "\n"]
+        with open(temporary_file_path, "w") as file:
+            file.write("\n".join(file_lines))
+
+        # Commit changed file
+        git_functions.push_updated_readme(
+            readme_path=temporary_file_path, commit_and_push=False
+        )
+
+        # Check whether file changed by git
+        command_result = subprocess.run(
+            ["git", "status"], capture_output=True, text=True
+        )
+
+        # Check if there is anything to commit
+        self.assertTrue(
+            str(temporary_file_path) in command_result.stdout,
+            "Check changed file staged",
+        )
+
+        # Reset git
+        reset_command = ["git", "reset", str(temporary_file_path)]
+        subprocess.run(reset_command, check=True)
 
         # Remove temporary file
         Path.unlink(temporary_file_path)

--- a/tests/test_git_functions.py
+++ b/tests/test_git_functions.py
@@ -1,0 +1,22 @@
+# Load packages
+import unittest  # running tests
+from pathlib import Path  # handling file paths
+
+# Local imports
+from python_coverage_badge import (
+    git_functions,
+)  # functions foir interacting with git
+
+
+# TODO add tests
+
+
+class TestGitFunctions(unittest.TestCase):
+    def test_check_if_file_changed_using_git(self):
+
+        # TODO Add test in here!
+        print("hello! Tests to add!")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_functions.py
+++ b/tests/test_git_functions.py
@@ -44,8 +44,8 @@ class TestGitFunctions(unittest.TestCase):
         )
 
         # Check whether file changed by git
-        command_result = subprocess.run(
-            ["git", "status"], capture_output=True, text=True
+        command_result = git_functions.send_command(
+            "git", "status", capture_output=True, text=True
         )
 
         # Check if there is anything to commit
@@ -55,11 +55,25 @@ class TestGitFunctions(unittest.TestCase):
         )
 
         # Reset git
-        reset_command = ["git", "reset", str(temporary_file_path)]
-        subprocess.run(reset_command, check=True)
+        command_result = git_functions.send_command(
+            "git", "reset", str(temporary_file_path)
+        )
 
         # Remove temporary file
         Path.unlink(temporary_file_path)
+
+    def test_send_command(self):
+
+        # Send a command in terminal
+        statement = "hello"
+        command_result = git_functions.send_command(
+            "echo", f'"{statement}"', capture_output=True, text=True
+        )
+
+        # Check the command result
+        self.assertTrue(
+            statement in command_result.stdout, "Check sending command in terminal"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,8 @@ class TestMain(unittest.TestCase):
         # TODO Add test in here!
         print("hello! Main test to add!")
 
+        self.assertTrue(True, "Adding empty test!")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Here I've added functionality (`--git_push`) flag to enable the updated `README.md` file (updated when badge updated) to be pushed to a repo. Default is for this to be turned off.

Main changes:
- Added new `python_coverage_badge/git_functions.py` script for all the functions required
- Updated command line interface (`python_coverage_badge/command_line_interface_functions.py` to have the additional `git_push` parameter
- Added unit tests for `git_functions.py` in `tests/test_git_functions.py` - these could be better as currently quite low coverage as avoiding committing and pushing any test changes 