### PR TITLE
Ignore patterns

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,0 +1,2 @@
+setup.py
+__init__.py

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 # Tasks
 
 - TODO improve coverage of tests for git functions if possible
-- TODO update README with ignore patterns info
 - TODO rename? shield_badger 🦡
 - TODO create logo
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 - TODO improve coverage of tests for git functions if possible
 - TODO update README with ignore patterns info
-- TODO rename?
+- TODO rename? shield_badger 🦡
 - TODO create logo
 
 # Installing `python_coverage_badge` 📦

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-83.5%25-4eb15d)
+![Code Coverage](https://img.shields.io/badge/coverage-84.4%25-4eb15d)
 
 # python_coverage_badge
 A package to create and maintain a package unit test coverage badge in python code README. Importantly there are quite a few python packages that do this task or similar:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 # Tasks
 
 - TODO improve coverage of tests for git functions if possible
-- TODO add patterns to ignore functionality (filter rows in coverage table)
+- TODO update README with ignore patterns info
 - TODO rename?
 - TODO create logo
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ options:
   -g, --git_push        Stage, commit, and push the updated README file (-r/--readme) using git. (default: False)
 ```
 
+# Ignoring patterns
+
+If you'd like to ignore the unit test coverage for particular files in your coverage report you can created a `.covignore` file in your repository directory. For example, here's the content of the `.covignore` file for this project:
+
+```
+setup.py
+__init__.py
+```
+
+The `.covignore` works in a similar way to a `.gitignore` file and any pattern found in it is passed to the [`str.contains()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.contains.html) function and used to filter the unit test coverage report before calculate the average coverage for the project. So the above means that any `setup.py` or `__init__.py` files are ignored.
+
 # For Developers
 
 ## Installation for development
@@ -69,6 +80,7 @@ Directory tree generated using [file-tree-generator](https://marketplace.visuals
  ┃ ┣ 📜test_main.py # unit tests for main script
  ┃ ┣ 📜test_unittest_coverage_functions.py # unit tests for functions to create/update coverage badge
  ┃ ┗ 📜__init__.py # package structure/info
+ ┣ 📜.covignore # patterns/files to ignore when calculating coverage
  ┣ 📜.gitignore
  ┣ 📜.pre-commit-config.yaml # precommit workflow
  ┣ 📜LICENSE

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 - TODO improve coverage of tests for git functions if possible
 - TODO add patterns to ignore functionality (filter rows in coverage table)
 - TODO rename?
+- TODO create logo
 
 # Installing `python_coverage_badge` 📦
 To install this package, follow these two steps:

--- a/python_coverage_badge/command_line_interface_functions.py
+++ b/python_coverage_badge/command_line_interface_functions.py
@@ -9,8 +9,6 @@ import os  # Change directory
 from python_coverage_badge import unittest_coverage_functions
 from python_coverage_badge import git_functions
 
-# TODO add git argument
-
 
 def build_command_line_interface() -> argparse.ArgumentParser:
     """Builds command line interface for python_coverage_badge package

--- a/python_coverage_badge/git_functions.py
+++ b/python_coverage_badge/git_functions.py
@@ -38,7 +38,6 @@ def check_if_file_changed_using_git(file_path: Path) -> bool:
     return True
 
 
-# TODO run python -m python_coverage_badge --git_push to test
 def push_updated_readme(
     readme_path: Path = Path("README.md"), commit_and_push: bool = True
 ):

--- a/python_coverage_badge/unittest_coverage_functions.py
+++ b/python_coverage_badge/unittest_coverage_functions.py
@@ -200,9 +200,17 @@ def replace_regex_in_file(
         file.write("\n".join(file_lines) + "\n")
 
 
-def load_patterns_to_ignore_in_coverage(
-    file_path: Path = Path(".covignore"),
-) -> pd.DataFrame:
+def load_patterns_to_ignore_in_coverage(file_path: Path = Path(".covignore")) -> [str]:
+    """Loads patterns from simple text file lines into list
+
+    Note file is like .gitignore so each line represents a pattern to ignore. Commented lines
+    can start with hash (#) and empty lines are ignored.
+    Args:
+        file_path (Path): path to file containing patterns
+
+    Returns:
+        [list] : list of patterns to ignore
+    """
 
     # Check if file exists
     if file_path.is_file():
@@ -212,8 +220,10 @@ def load_patterns_to_ignore_in_coverage(
         with open(file_path) as file:
             file_lines = file.read().splitlines()
 
-        # Ignore comment lines
-        file_lines = [line for line in file_lines if not line.startswith("#")]
+        # Ignore comment or empty lines
+        file_lines = [
+            line for line in file_lines if not line.startswith("#") or not line == ""
+        ]
 
         return file_lines
 

--- a/python_coverage_badge/unittest_coverage_functions.py
+++ b/python_coverage_badge/unittest_coverage_functions.py
@@ -9,7 +9,9 @@ import warnings  # send warnings
 import seaborn  # create colour palette
 
 
-def parse_coverage_report(coverage_report_string: str) -> pd.DataFrame:
+def parse_coverage_report(
+    coverage_report_string: str, patterns_to_ignore: [str] = None
+) -> pd.DataFrame:
     """Parses byte string returned by coverage report into pandas dataframe
 
     Args:
@@ -28,6 +30,13 @@ def parse_coverage_report(coverage_report_string: str) -> pd.DataFrame:
 
     # Remove percent sign from coverage column and convert to float
     coverage_dataframe.Cover = coverage_dataframe.Cover.str[:-1].astype(float)
+
+    # Check if any patterns to ignore
+    if not patterns_to_ignore == None:
+        patterns_to_ignore = "|".join(patterns_to_ignore)
+        coverage_dataframe = coverage_dataframe[
+            ~coverage_dataframe.Name.str.contains(patterns_to_ignore)
+        ]
 
     return coverage_dataframe
 
@@ -74,8 +83,11 @@ def run_code_coverage() -> pd.DataFrame:
                 f"Generating coverage report command ({' '.join(report_command)}) failed! Return code: {error.returncode}"
             )
 
+        # Get patterns to ignore
+        patterns_to_ignore = load_patterns_to_ignore_in_coverage()
+
         # Convert coverage report output to dataframe
-        report_dataframe = parse_coverage_report(coverage_report)
+        report_dataframe = parse_coverage_report(coverage_report, patterns_to_ignore)
 
     else:
         warnings.warn(
@@ -186,3 +198,24 @@ def replace_regex_in_file(
     # Write file lines back to file
     with open(file_path, "w") as file:
         file.write("\n".join(file_lines) + "\n")
+
+
+def load_patterns_to_ignore_in_coverage(
+    file_path: Path = Path(".covignore"),
+) -> pd.DataFrame:
+
+    # Check if file exists
+    if file_path.is_file():
+
+        # Get the file lines from the file
+        file_lines = []
+        with open(file_path) as file:
+            file_lines = file.read().splitlines()
+
+        # Ignore comment lines
+        file_lines = [line for line in file_lines if not line.startswith("#")]
+
+        return file_lines
+
+    else:
+        return None

--- a/python_coverage_badge/unittest_coverage_functions.py
+++ b/python_coverage_badge/unittest_coverage_functions.py
@@ -221,9 +221,10 @@ def load_patterns_to_ignore_in_coverage(file_path: Path = Path(".covignore")) ->
             file_lines = file.read().splitlines()
 
         # Ignore comment or empty lines
-        file_lines = [
-            line for line in file_lines if not line.startswith("#") or not line == ""
-        ]
+        file_lines = [line for line in file_lines if not line.startswith("#")]
+
+        # Remove empty values
+        file_lines = list(filter(None, file_lines))
 
         # Check if no lines present
         file_lines = None if len(file_lines) == 0 else file_lines

--- a/python_coverage_badge/unittest_coverage_functions.py
+++ b/python_coverage_badge/unittest_coverage_functions.py
@@ -225,6 +225,9 @@ def load_patterns_to_ignore_in_coverage(file_path: Path = Path(".covignore")) ->
             line for line in file_lines if not line.startswith("#") or not line == ""
         ]
 
+        # Check if no lines present
+        file_lines = None if len(file_lines) == 0 else file_lines
+
         return file_lines
 
     else:

--- a/tests/test_unittest_coverage_functions.py
+++ b/tests/test_unittest_coverage_functions.py
@@ -134,7 +134,52 @@ class TestUnittestCoverageFunctions(unittest.TestCase):
                 f"Checking getting badge colour for value = {value} (should be {colour})",
             )
 
-    # TODO add test for load_patterns_to_ignore_in_coverage()
+    def test_load_patterns_to_ignore_in_coverage(self):
+
+        # Create temporary file
+        temporary_file_path = Path("test.covignore")
+        file_lines = [
+            "ignore",
+            "\n",
+            "# Ignore this comment",
+            "\n",
+            "this",
+            "\n",
+            "pattern",
+            "\n",
+        ]
+        with open(temporary_file_path, "w") as file:
+            file.write("\n".join(file_lines))
+
+        # Load the patterns from temp file
+        patterns = unittest_coverage_functions.load_patterns_to_ignore_in_coverage(
+            file_path=temporary_file_path
+        )
+
+        # Check patterns loaded correctly
+        self.assertEqual(
+            patterns[0],
+            "ignore",
+            "Check pattern read in",
+        )
+        self.assertEqual(
+            patterns[1],
+            "this",
+            "Check pattern read in",
+        )
+        self.assertEqual(
+            patterns[2],
+            "pattern",
+            "Check pattern read in",
+        )
+        self.assertEqual(
+            len(patterns),
+            3,
+            "Check correct number of patterns loaded",
+        )
+
+        # Remove temporary file
+        Path.unlink(temporary_file_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_unittest_coverage_functions.py
+++ b/tests/test_unittest_coverage_functions.py
@@ -134,6 +134,8 @@ class TestUnittestCoverageFunctions(unittest.TestCase):
                 f"Checking getting badge colour for value = {value} (should be {colour})",
             )
 
+    # TODO add test for load_patterns_to_ignore_in_coverage()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added option to specify file names/patterns to ignore in the coverage report. Added and updated `python_coverage_badge/unittest_coverage_functions.py` and `tests/test_unittest_coverage_functions.py`