### PR TITLE
Pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ To update the coverage badge of your repo, run the following from within the **r
 python -m coverage_shield
 ```
 
-There are a couple of command line arguments you can use, take a look with `python -m coverage_shield --help`:
+There are a few command line arguments you can use, take a look with `python -m coverage_shield --help`:
 ```
-usage: coverage_shield [-h] [-d [directory]] [-r [readme_path]] [-g]
+usage: coverage_shield [-h] [-d [directory]] [-r [readme_path]] [-t [tester]] [-g]
 
 Welcome to coverage_shield! A tool to create and maintain a python package unit test coverage badge in README.md
 
@@ -46,6 +46,8 @@ options:
                         Provide path to directory to run coverage_shield in. (default: .)
   -r [readme_path], --readme [readme_path]
                         Provide path to README.md relative to directory provided. (default: README.md)
+  -t [tester], --tester [tester]
+                        Provide name of unit test python package you want to use. Accepts either "unittest" or "pytest" (default: unittest)
   -g, --git_push        Stage, commit, and push the updated README file (-r/--readme) using git. (default: False)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![Code Coverage](https://img.shields.io/badge/coverage-84.4%25-4eb15d)
+![Code Coverage](https://img.shields.io/badge/coverage-83.4%25-54b45f)
 [![Python package](https://github.com/JosephCrispell/coverage_shield/actions/workflows/python-package.yml/badge.svg)](https://github.com/JosephCrispell/coverage_shield/actions/workflows/python-package.yml)
 
 <img src="images/logo.svg" alt="timesheet logo" align="right" width="15%">

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ https://img.shields.io/badge/coverage-{average_coverage}%25-{badge_colour}
 
 # Tasks
 
+- TODO create a release
+- TODO look into getting published on pip
 - TODO improve coverage of tests for git functions if possible
 
 # Installing `coverage_shield` 📦

--- a/coverage_shield/command_line_interface_functions.py
+++ b/coverage_shield/command_line_interface_functions.py
@@ -52,6 +52,15 @@ def build_command_line_interface() -> argparse.ArgumentParser:
         help="Provide path to README.md relative to directory provided.",
     )
     parser.add_argument(
+        "-t",
+        "--tester",
+        nargs="?",  # Accept 0 or 1 arguments
+        default="unittest",  # Default value
+        metavar="tester",
+        type=str,
+        help="Provide name of unit test python package you want to use. Accepts either \"unittest\" or \"pytest\"",
+    )
+    parser.add_argument(
         "-g",
         "--git_push",
         action="store_true",
@@ -86,8 +95,8 @@ def parse_command_line_arguments(
         # Set target directory
         os.chdir(args.directory)
 
-        # Run coverage package (which runs unittests and generates report
-        coverage_dataframe = unittest_coverage_functions.run_code_coverage()
+        # Run coverage package (which runs unit tests and generates report)
+        coverage_dataframe = unittest_coverage_functions.run_code_coverage(args.tester)
 
         # Build the badge url
         coverage_badge_url = unittest_coverage_functions.make_coverage_badge_url(

--- a/coverage_shield/unittest_coverage_functions.py
+++ b/coverage_shield/unittest_coverage_functions.py
@@ -41,7 +41,7 @@ def parse_coverage_report(
     return coverage_dataframe
 
 
-def run_code_coverage() -> pd.DataFrame:
+def run_code_coverage(tester: str = "unittest") -> pd.DataFrame:
     """Runs coverage tool in command line and returns report
 
     Will send warning if running coverage package is failing and return empty dataframe
@@ -50,7 +50,10 @@ def run_code_coverage() -> pd.DataFrame:
         pd.DataFrame : coverage report as dataframe if coverage passing; empty dataframe if coverage failing
     """
 
-    # Change to the directory provided
+    # Check tester option provided
+    tester_options = ["unittest", "pytest"]
+    if not tester in tester_options:
+        raise ValueError(f"The tester option provided ({tester}) was not recognised. Must be one of: {tester_options.join(', ')}")
 
     # Run code coverage calculation
     # Check out useful subprocess function docs: https://www.datacamp.com/tutorial/python-subprocess
@@ -61,7 +64,7 @@ def run_code_coverage() -> pd.DataFrame:
         "run",
         "--source=.",
         "-m",
-        "unittest",
+        tester,
     ]
     command_result = subprocess.run(coverage_command, capture_output=True, text=True)
 


### PR DESCRIPTION
Added functionality so that [`pytest`](https://docs.pytest.org/en/7.4.x/) can be used to run unit tests as well as [`unittest`](https://docs.python.org/3/library/unittest.html). Main change was to `run_code_coverage()` function in `coverage_shield/unittest_coverage_functions.py` and also updates to the command line interface in `coverage_shield/command_line_interface_functions.py`